### PR TITLE
Respect timezone when select time

### DIFF
--- a/lib/QMBForm/src/main/java/com/quemb/qmbform/view/FormTimeDialogFieldCell.java
+++ b/lib/QMBForm/src/main/java/com/quemb/qmbform/view/FormTimeDialogFieldCell.java
@@ -45,10 +45,11 @@ public class FormTimeDialogFieldCell extends FormTimeFieldCell implements
     @Override
     public void onTimeSet(TimePicker view, int hourOfDay, int minute) {
 
-        Date date = new Date();
-        date.setTime(TimeUnit.HOURS.toMillis(hourOfDay)+TimeUnit.MINUTES.toMillis(minute));
+        Calendar calendar = getCalendar();
+        calendar.set(Calendar.HOUR_OF_DAY, hourOfDay);
+        calendar.set(Calendar.MINUTE, minute);
 
-        onDateChanged(date);
+        onDateChanged(calendar.getTime());
 
     }
 


### PR DESCRIPTION
Interesting, that when creating timepicker, you did used Calendar (which respects timezone), but when listening for changes, you did not. Fixed that.
